### PR TITLE
Option to change encoding error parameter

### DIFF
--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -158,4 +158,4 @@ def rtf_to_text(text, errors='strict'):
             elif not ignorable:
                 out = out + tchar.encode(encoding, errors)
 
-    return out.decode(encoding)
+    return out.decode(encoding, errors)


### PR DESCRIPTION
### Issue

Certain Unicode chars cause 'rtf_to_text()' to throw the below 'UnicodeEncodeError':
'UnicodeEncodeError: 'charmap' codec can't encode character '\u018f' in position 0: character maps to undefined'.

This occurred with the following chars:
['\u018f', '\u2003', '\u2002', '\u2008', '\u202f', '\ufb02', '\u0422', '\u200a', '\ufb01', '\u0131']

### Fix

These exceptions can be caught however, it is tedious to solve the issue via this route especially given the fact they are mostly redundant chars that would be removed during data sanitisation.

A quick solution is to create an optional parameter to pass the already established 'error' parameter of 'encode()'. 

Therefore errors can be avoided via the 'ignore' option and the rest of the script can run.
