### PR TITLE
Add License classifier for pypa

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     % about["__version__"],
     keywords=["rtf"],
     scripts=["striprtf/striprtf"],
+    license="BSD-3-Clause",
     classifiers=[
         "License :: OSI Approved :: BSD License",
     ],


### PR DESCRIPTION
Add the license classifier for pypa. Only the general license can be specified, as a bsd 3-clause identifier is [missing](https://github.com/pypa/trove-classifiers/issues/17).