### PR TITLE
Add py.typed marker for MyPy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ packages = ["striprtf"]
 [tool.hatch.build.targets.sdist]
 include = [
     "striprtf/**/*.py",
+    "striprtf/py.typed",
     "README.md",
     "LICENSE",
 ]


### PR DESCRIPTION
This adds a PEP 561 `py.typed` marker file to the `striprtf` package and
ensures it is included in package data, so that MyPy recognizes the
package as typed and avoids `Skipping analyzing ...` errors.