### PR TITLE
Add type annotations and mypy CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,5 @@ jobs:
         run: uv run pytest tests
 
       - name: Run mypy
+        if: matrix.python-version == '3.13'
         run: uv run mypy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: striprtf build
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,6 @@ jobs:
   
       - name: Run tests
         run: uv run pytest tests
+
+      - name: Run mypy
+        run: uv run mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest>=7.0.0",
     "build>=1.0.0",
     "twine>=6.1.0",
+    "mypy>=1.0.0",
 ]
 
 [tool.hatch.version]
@@ -50,6 +51,11 @@ include = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+files = ["striprtf"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 
 [tool.mypy]
+# mypy 1.x dropped Python 3.8 support; 3.9 is the minimum supported target version.
+# The package itself still supports Python 3.8 at runtime.
 python_version = "3.9"
 strict = true
 files = ["striprtf"]

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import codecs
+from typing import Literal
 
 """
 Taken from https://gist.github.com/gilsondev/7c1d2d753ddb522e7bc22511cfb08676
@@ -180,7 +181,11 @@ def remove_pict_groups(rtf_text: str) -> str:
 
 FONTTABLE: re.Pattern[str] = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
 
-def rtf_to_text(text: str, encoding: str = "cp1252", errors: str = "strict") -> str:
+def rtf_to_text(
+    text: str,
+    encoding: str = "cp1252",
+    errors: Literal["strict", "ignore", "replace", "xmlcharrefreplace", "backslashreplace", "namereplace", "surrogateescape", "surrogatepass"] = "strict",
+) -> str:
     """Converts the rtf text to plain text.
 
     Parameters

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import codecs
-from typing import Optional
 
 """
 Taken from https://gist.github.com/gilsondev/7c1d2d753ddb522e7bc22511cfb08676
@@ -208,13 +207,13 @@ def rtf_to_text(text: str, encoding: str = "cp1252", errors: str = "strict") -> 
     )  # captures links like link_text(http://link_dest)
     stack: list[tuple[int, bool, bool]] = []
     fonttbl: dict[str, dict[str, str]] = {}
-    default_font: Optional[str] = None
-    current_font: Optional[str] = None
+    default_font: str | None = None
+    current_font: str | None = None
     ignorable: bool = False  # Whether this group (and all inside it) are "ignorable".
     suppress_output: bool = False  # Whether this group (and all inside it) are "ignorable".
     ucskip: int = 1  # Number of ASCII characters to skip after a unicode character.
     curskip: int = 0  # Number of ASCII characters left to skip
-    hexes: Optional[str] = None
+    hexes: str | None = None
     out: str = ""
 
     # Simplified font table regex

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import re
 import codecs
+from typing import Optional
 
 """
 Taken from https://gist.github.com/gilsondev/7c1d2d753ddb522e7bc22511cfb08676
@@ -8,7 +11,7 @@ and modified for better output of tables.
 
 # fmt: off
 # control words which specify a "destination".
-destinations = frozenset((
+destinations: frozenset[str] = frozenset((
     'aftncn','aftnsep','aftnsepc','annotation','atnauthor','atndate','atnicn','atnid',
     'atnparent','atnref','atntime','atrfend','atrfstart','author','background',
     'bkmkend','bkmkstart','blipuid','buptim','category','colorschememapping',
@@ -51,7 +54,7 @@ destinations = frozenset((
     'xmlopen',
 ))
 # fmt: on
-charset_map = {
+charset_map: dict[int, str] = {
     0: "cp1252",  # Default
     42: "cp1252",  # Symbol
     77: "mac_roman",  # Mac Roman
@@ -87,8 +90,8 @@ charset_map = {
 
 # Translation of some special characters.
 # and section characters reset formatting
-sectionchars = {"par": "\n", "sect": "\n\n", "page": "\n\n"}
-specialchars = {
+sectionchars: dict[str, str] = {"par": "\n", "sect": "\n\n", "page": "\n\n"}
+specialchars: dict[str, str] = {
     **{
         "line": "\n",
         "tab": "\t",
@@ -117,18 +120,18 @@ specialchars = {
     **sectionchars,
 }
 
-PATTERN = re.compile(
+PATTERN: re.Pattern[str] = re.compile(
     r"\\([a-z]{1,32})(-?\d{1,10})?[ ]?|\\'([0-9a-f]{2})|\\([^a-z])|([{}])|[\r\n]+|(.)",
     re.IGNORECASE,
 )
 
-HYPERLINKS = re.compile(
+HYPERLINKS: re.Pattern[str] = re.compile(
     r"(\{\\field\{\s*\\\*\\fldinst\{.*HYPERLINK\s(\".*\")\}{2}\s*\{.*?\s+(.*?)\}{2,3})",
     re.IGNORECASE,
 )
 
 
-def remove_pict_groups(rtf_text):
+def remove_pict_groups(rtf_text: str) -> str:
     """
     Remove all \\pict groups with binary data from the RTF text.
     If no binary-encoded \\pict groups are found, return the original text.
@@ -176,9 +179,9 @@ def remove_pict_groups(rtf_text):
 
     return "".join(result)
 
-FONTTABLE = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
+FONTTABLE: re.Pattern[str] = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
 
-def rtf_to_text(text, encoding="cp1252", errors="strict"):
+def rtf_to_text(text: str, encoding: str = "cp1252", errors: str = "strict") -> str:
     """Converts the rtf text to plain text.
 
     Parameters
@@ -203,16 +206,16 @@ def rtf_to_text(text, encoding="cp1252", errors="strict"):
     text = re.sub(
         HYPERLINKS, "\\1(\\2)", text
     )  # captures links like link_text(http://link_dest)
-    stack = []
-    fonttbl = {}
-    default_font = None
-    current_font = None
-    ignorable = False  # Whether this group (and all inside it) are "ignorable".
-    suppress_output = False  # Whether this group (and all inside it) are "ignorable".
-    ucskip = 1  # Number of ASCII characters to skip after a unicode character.
-    curskip = 0  # Number of ASCII characters left to skip
-    hexes = None
-    out = ""
+    stack: list[tuple[int, bool, bool]] = []
+    fonttbl: dict[str, dict[str, str]] = {}
+    default_font: Optional[str] = None
+    current_font: Optional[str] = None
+    ignorable: bool = False  # Whether this group (and all inside it) are "ignorable".
+    suppress_output: bool = False  # Whether this group (and all inside it) are "ignorable".
+    ucskip: int = 1  # Number of ASCII characters to skip after a unicode character.
+    curskip: int = 0  # Number of ASCII characters left to skip
+    hexes: Optional[str] = None
+    out: str = ""
 
     # Simplified font table regex
     fonttbl_matches = FONTTABLE.findall(text)
@@ -227,7 +230,7 @@ def rtf_to_text(text, encoding="cp1252", errors="strict"):
         if hexes and not _hex:
             # Decode accumulated hexes
             out += bytes.fromhex(hexes).decode(
-                encoding=fonttbl.get(current_font, {"encoding": encoding}).get(
+                encoding=fonttbl.get(current_font or "", {"encoding": encoding}).get(
                     "encoding", encoding
                 ),
                 errors=errors,

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -230,8 +230,10 @@ def rtf_to_text(text: str, encoding: str = "cp1252", errors: str = "strict") -> 
         if hexes and not _hex:
             # Decode accumulated hexes
             out += bytes.fromhex(hexes).decode(
-                encoding=fonttbl.get(current_font or "", {"encoding": encoding}).get(
-                    "encoding", encoding
+                encoding=(
+                    fonttbl[current_font].get("encoding", encoding)
+                    if current_font is not None and current_font in fonttbl
+                    else encoding
                 ),
                 errors=errors,
             )

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import codecs
-from typing import Literal
 
 """
 Taken from https://gist.github.com/gilsondev/7c1d2d753ddb522e7bc22511cfb08676
@@ -181,11 +180,7 @@ def remove_pict_groups(rtf_text: str) -> str:
 
 FONTTABLE: re.Pattern[str] = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
 
-def rtf_to_text(
-    text: str,
-    encoding: str = "cp1252",
-    errors: Literal["strict", "ignore", "replace", "xmlcharrefreplace", "backslashreplace", "namereplace", "surrogateescape", "surrogatepass"] = "strict",
-) -> str:
+def rtf_to_text(text: str, encoding: str = "cp1252", errors: str = "strict") -> str:
     """Converts the rtf text to plain text.
 
     Parameters


### PR DESCRIPTION
Hi 👋!
Now that the package exports type hints (#62) , it should have some too 😉

These changes were done by an [LLM-Agent](https://github.com/farmio/striprtf/tasks/efe617c5-40ad-41ea-b02d-688ae4d63319) and reviewed by a human (me).

This pull request introduces type annotations and stricter type checking to the `striprtf` codebase, improving code quality and maintainability. It also enhances the CI workflow by adding static type checking with `mypy` and updates development dependencies accordingly.

**Type annotations and code improvements:**

* Added type annotations throughout `striprtf/striprtf.py`, including variable, function, and regex pattern types, to improve code clarity and enable static analysis. [[1]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036R1-R2) [[2]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L11-R13) [[3]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L54-R56) [[4]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L90-R93) [[5]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L120-R133) [[6]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L179-R183) [[7]](diffhunk://#diff-2fb4e06ed2a5932b92511a5568a2aeb23fd7c4feb63567b26bd6402a187b0036L206-R217)
* Refined logic for font encoding selection in `rtf_to_text` to use safer dictionary access with type-aware checks.

**Development tooling and CI:**

* Added `mypy` as a development dependency in `pyproject.toml` and configured strict type checking for the `striprtf` package. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R34) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R55-R61)
* Updated the GitHub Actions workflow to run `mypy` type checks on Python 3.13 during CI, in addition to running tests.
* Modified the workflow trigger to include both `push` and `pull_request` events, ensuring checks run on all contributions.