### PR TITLE
Fix fonttbl bottleneck

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,8 +45,6 @@ For verbose output:
 pytest -v
 ```
 
-On Windows, make sure Python uses UTF-8, for example by setting the environment variable `PYTHONUTF8=1`.
-
 ## Debugging
 
 For debugging with `debugpy`, install it first:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,6 +45,8 @@ For verbose output:
 pytest -v
 ```
 
+On Windows, make sure Python uses UTF-8, for example by setting the environment variable `PYTHONUTF8=1`.
+
 ## Debugging
 
 For debugging with `debugpy`, install it first:

--- a/striprtf/striprtf.py
+++ b/striprtf/striprtf.py
@@ -176,7 +176,41 @@ def remove_pict_groups(rtf_text):
 
     return "".join(result)
 
-FONTTABLE = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
+
+CHARSET = re.compile(r"\\f(\d+).*?\\fcharset(\d+).*?([^;]+);")
+FONTTABLE = re.compile(r"{[^{]*\\fonttbl")
+
+
+def get_fonttable_str(text):
+    """
+    Helper to extract the font table from the RTF text.
+
+    Parameters
+    ----------
+    text : str
+        The RTF text.
+
+    Returns
+    -------
+    str
+        Text containing only the font table.
+    """
+    # extract substring containing font table
+    fonttable_match = FONTTABLE.search(text)
+    if not fonttable_match:
+        return ""
+    fonttable_text = fonttable_match.group()
+    pdepth = 1
+    for c in text[fonttable_match.end() :]:
+        fonttable_text += c
+        if c == "{":
+            pdepth += 1
+        elif c == "}":
+            pdepth -= 1
+        if pdepth == 0:
+            break
+    return fonttable_text
+
 
 def rtf_to_text(text, encoding="cp1252", errors="strict"):
     """Converts the rtf text to plain text.
@@ -214,14 +248,14 @@ def rtf_to_text(text, encoding="cp1252", errors="strict"):
     hexes = None
     out = ""
 
-    # Simplified font table regex
-    fonttbl_matches = FONTTABLE.findall(text)
-    for font_id, fcharset, font_name in fonttbl_matches:
+    # match font table entries
+    for font_id, fcharset, font_name in CHARSET.findall(get_fonttable_str(text)):
         fonttbl[font_id] = {
             "name": font_name.strip(),
             "charset": fcharset,
             "encoding": charset_map.get(int(fcharset), encoding),
         }
+
     for match in PATTERN.finditer(text):
         word, arg, _hex, char, brace, tchar = match.groups()
         if hexes and not _hex:

--- a/tests/test_bytes.py
+++ b/tests/test_bytes.py
@@ -14,5 +14,5 @@ class TestBytes(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_calcium_score.py
+++ b/tests/test_calcium_score.py
@@ -14,5 +14,5 @@ class TestSimple(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -14,5 +14,5 @@ class TestEncoding(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read(), errors="ignore")
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_french.py
+++ b/tests/test_french.py
@@ -14,6 +14,6 @@ class TestSimple(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -14,5 +14,5 @@ class TestHello(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_hyperlink_replacement.py
+++ b/tests/test_hyperlink_replacement.py
@@ -14,5 +14,5 @@ class TestSimple(unittest.TestCase):
 
         with hyperlink_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with hyperlink_txt.open() as destination:
+        with hyperlink_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_hyperlinks.py
+++ b/tests/test_hyperlinks.py
@@ -15,7 +15,7 @@ class TestHyperlinks(unittest.TestCase):
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_mac_textedit(self):
@@ -25,7 +25,7 @@ class TestHyperlinks(unittest.TestCase):
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_user_sample(self):
@@ -35,5 +35,5 @@ class TestHyperlinks(unittest.TestCase):
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_issue_11.py
+++ b/tests/test_issue_11.py
@@ -15,5 +15,5 @@ class TestUnicodeSimplifiedChinese(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_issue_20.py
+++ b/tests/test_issue_20.py
@@ -14,5 +14,5 @@ class UnknownEncoding(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_issue_29.py
+++ b/tests/test_issue_29.py
@@ -15,7 +15,7 @@ class TestCyrillic(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_bad(self):
@@ -24,5 +24,5 @@ class TestCyrillic(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_issue_37.py
+++ b/tests/test_issue_37.py
@@ -14,5 +14,5 @@ class Encoding(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_issue_38.py
+++ b/tests/test_issue_38.py
@@ -31,7 +31,7 @@ class Table(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_table_string(self):

--- a/tests/test_issue_55.py
+++ b/tests/test_issue_55.py
@@ -16,7 +16,7 @@ class Fonttbl(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_fonttbl_file1(self):
@@ -26,6 +26,6 @@ class Fonttbl(unittest.TestCase):
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
             print("result:::", result)
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
   

--- a/tests/test_issue_58.py
+++ b/tests/test_issue_58.py
@@ -17,7 +17,7 @@ class TestPartialConversion(unittest.TestCase):
             raw = source.read()
             result = rtf_to_text(raw, errors="ignore")
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
    

--- a/tests/test_issue_63.py
+++ b/tests/test_issue_63.py
@@ -21,5 +21,5 @@ class TestListtextNumbering(unittest.TestCase):
             raw = source.read()
             result = rtf_to_text(raw)
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_line_breaks_google_docs.py
+++ b/tests/test_line_breaks_google_docs.py
@@ -14,6 +14,6 @@ class TestSimple(unittest.TestCase):
 
         with simple_table_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with simple_table_txt.open() as destination:
+        with simple_table_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 

--- a/tests/test_line_breaks_textedit_mac.py
+++ b/tests/test_line_breaks_textedit_mac.py
@@ -18,6 +18,6 @@ class TestSimple(unittest.TestCase):
 
         with simple_table_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with simple_table_txt.open() as destination:
+        with simple_table_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 

--- a/tests/test_nested_table.py
+++ b/tests/test_nested_table.py
@@ -14,5 +14,5 @@ class TestSimple(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_nutridoc.py
+++ b/tests/test_nutridoc.py
@@ -15,6 +15,6 @@ class TestSimple(unittest.TestCase):
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
 
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 

--- a/tests/test_sample_3.py
+++ b/tests/test_sample_3.py
@@ -14,5 +14,5 @@ class TestSimple(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -14,7 +14,7 @@ class TestSimple(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 
     def test_table(self):
@@ -23,6 +23,6 @@ class TestSimple(unittest.TestCase):
 
         with simple_table_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with simple_table_txt.open() as destination:
+        with simple_table_txt.open(encoding="utf-8") as destination:
             self.assertEqual(destination.read(), result)
 

--- a/tests/test_speiseplan.py
+++ b/tests/test_speiseplan.py
@@ -14,7 +14,7 @@ class TestSpeiseplan(unittest.TestCase):
 
         with example_rtf.open() as source:
             result = rtf_to_text(source.read())
-        with example_txt.open() as destination:
+        with example_txt.open(encoding="utf-8") as destination:
             self.maxDiff = None
             self.assertEqual(destination.read(), result)
 


### PR DESCRIPTION
Hey @joshy,

Thanks for maintaining what seems to be one of the only RTF parsers for Python.

I used this package and noticed that it takes some time to parse large RTF files. We are talking about more than 300 pages sometimes, which took over 3 minutes on my machine. I investigated this issue and it seems that the regex matching the font table entries is quite expensive to run against the entire text.

To address this, I added a helper method to extract the font table out of the text by simply counting opening and closing braces. The original regex is then used to search only this part of the text. You could probably parse the font table entries directly when counting braces, but I am not that deep in the RTF-spec at all, so I leave this to the experts😉.

Btw., one could probably also use similar logic to solve #69.

I also added a brief hint for developers on Windows as I ran into encoding issues while executing pytest.